### PR TITLE
Remove Anaconda credentials

### DIFF
--- a/.travis/after_success.sh
+++ b/.travis/after_success.sh
@@ -6,9 +6,6 @@ set -e
 # Close the after_success fold travis has created already.
 travis_fold end after_success
 
-ANACONDA_TOKEN="BSmKM9rKvv9D"
-ANACONDA_USER="Quicklogic-Corp"
-
 if [[ $UPLOAD == "no-upload" ]]; then
     echo "Job without upload..."
 else


### PR DESCRIPTION
These credentials should be set in Travis settings.

Otherwise it's impossible to set your own credentials in a fork of this
repository, without actually changing the code.