### PR TITLE
Yosys share path fix and additional stage for yosys-plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: shell
 stages:
   - "EDA Tools - Simulation"
   - "EDA Tools - Synthesis"
+  - "EDA Tools - Synthesis Addons"
   - "EDA Tools - PnR"
 
 jobs:
@@ -21,7 +22,7 @@ jobs:
     dist: xenial
     env:
     - PACKAGE=yosys CUSTOM_LABEL=ql
-  - stage: "EDA Tools - Synthesis"
+  - stage: "EDA Tools - Synthesis Addons"
     os: linux
     dist: xenial
     env:

--- a/yosys/kernel_yosys_fix_share_path.patch
+++ b/yosys/kernel_yosys_fix_share_path.patch
@@ -1,0 +1,17 @@
+diff --git a/kernel/yosys.cc b/kernel/yosys.cc
+index 2ec3dca0..ff87ddbf 100644
+--- a/kernel/yosys.cc
++++ b/kernel/yosys.cc
+@@ -844,7 +844,11 @@ std::string proc_share_dirname()
+ 	std::string proc_share_path = proc_self_path + "share/";
+ 	if (check_file_exists(proc_share_path, true))
+ 		return proc_share_path;
+-	proc_share_path = proc_self_path + "../share/" + proc_program_prefix()+ "yosys/";
++	if (proc_program_prefix().empty()) {
++		proc_share_path = proc_self_path + "../share/yosys/";
++	} else {
++		proc_share_path = proc_self_path + "../share/" + proc_program_prefix() + "yosys/";
++	}
+ 	if (check_file_exists(proc_share_path, true))
+ 		return proc_share_path;
+ #    ifdef YOSYS_DATDIR

--- a/yosys/meta.yaml
+++ b/yosys/meta.yaml
@@ -9,7 +9,7 @@ source:
    git_rev: quicklogic-rebased
    patches:
      - makefile-conda-config.patch
-       #     - disable-failing-ecp5-mux.patch
+     - kernel_yosys_fix_share_path.patch
 
 build:
   # number: 201803050325


### PR DESCRIPTION
PR includes a proper patch to Yosys which fixes broken "share" path. Additionally I added a stage for `yosys-plugins` after `yosys` build - this will enable Travis to use the latest `yosys` package generated from the same runner.